### PR TITLE
Fix the example for Serialize.record

### DIFF
--- a/src/Serialize.elm
+++ b/src/Serialize.elm
@@ -683,11 +683,11 @@ type RecordCodec e a b
 
     pointCodec : S.Codec Point
     pointCodec =
-        S.object Point
+        S.record Point
             -- Note that adding, removing, or reordering fields will prevent you from decoding any data you've previously encoded.
             |> S.field .x S.int
             |> S.field .y S.int
-            |> S.finishObject
+            |> S.finishRecord
 
 -}
 record : b -> RecordCodec e a b


### PR DESCRIPTION
It was saying object/finishObject, which I imagine are outdated names.