### PR TITLE
correct spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # elm-serialize
 
 Quickly and reliably write code to handle serialization of Elm data structures. 
-This is done via `Codec`s which automatically create both the encoder and decoder ensuring that they don't get out of sync with eachother.
+This is done via `Codec`s which automatically create both the encoder and decoder ensuring that they don't get out of sync with each other.
 
 ### What elm-serialize is good for?
 - Sparing you from having to write both encoders and decoders

--- a/src/Serialize.elm
+++ b/src/Serialize.elm
@@ -269,7 +269,7 @@ encodeToBytes codec value =
 
 {-| Convert an Elm value into a string. This string contains only url safe characters, so you can do the following:
 
-    import Serlialize as S
+    import Serialize as S
 
     myUrl =
         "www.mywebsite.com/?data=" ++ S.encodeToString S.float 1234

--- a/tests/AstCodec.elm
+++ b/tests/AstCodec.elm
@@ -225,6 +225,7 @@ function =
         |> S.finishRecord
 
 
+signature : Codec e Signature
 signature =
     S.record Signature
         |> S.field .name (node S.string)

--- a/tests/AstCodecV1.elm
+++ b/tests/AstCodecV1.elm
@@ -225,6 +225,7 @@ function =
         |> S.finishRecord
 
 
+signature : Codec e Signature
 signature =
     S.record Signature
         |> S.field .name (node S.string)

--- a/tests/FileSizeTests.elm
+++ b/tests/FileSizeTests.elm
@@ -326,7 +326,7 @@ encodeToBytes codec value =
 
 {-| Convert an Elm value into a string. This string contains only url safe characters, so you can do the following:
 
-    import Serlialize as S
+    import Serialize as S
 
     myUrl =
         "www.mywebsite.com/?data=" ++ S.encodeToString S.float 1234

--- a/tests/SerializeV1.elm
+++ b/tests/SerializeV1.elm
@@ -271,7 +271,7 @@ encodeToBytes codec value =
 
 {-| Convert an Elm value into a string. This string contains only url safe characters, so you can do the following:
 
-    import Serlialize as S
+    import Serialize as S
 
     myUrl =
         "www.mywebsite.com/?data=" ++ S.encodeToString S.float 1234


### PR DESCRIPTION
corrected spelling
```
- Serlialize
+ Serialize
```
in multiple files,
```
- Serizlier version
+ Serializer version
```
in `tests/Base` and
```
- eachother
+ each other
```
in the readme.

Apart from that, I added some type annotations, but you can remove them if you don't want them.